### PR TITLE
Fix: Enforce password validation to require minimum of 8 characters

### DIFF
--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -18,14 +18,19 @@ export default function SignIn() {
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.id]: e.target.value.trim() });
   };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!formData.email || !formData.password) {
       return dispatch(signInFailure("All fields are required"));
-      // dispatch(signInFailure("All fields are required"));    (both work fine)
     }
+
+    if (formData.password.length < 8) {
+      return dispatch(signInFailure("Password must be at least 8 characters long"));
+    }
+
     try {
-      dispatch(signInStart())
+      dispatch(signInStart());
       const res = await fetch("/api/auth/signin", {
         method: "POST",
         headers: {
@@ -36,9 +41,8 @@ export default function SignIn() {
       const data = await res.json();
       if (data.success === false) {
         return dispatch(signInFailure(data.message));
-        // dispatch(signInFailure(data.message));    (both work fine)
       }
-      if(res.ok) {
+      if (res.ok) {
         dispatch(signInSuccess(data));
         navigate("/");
       }

--- a/client/src/pages/SignUp.jsx
+++ b/client/src/pages/SignUp.jsx
@@ -26,9 +26,17 @@ export default function SignUp() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!formData.username || !formData.email || !formData.password) {
+    const { username, email, password } = formData;
+
+    if (!username || !email || !password) {
       return dispatch(signInFailure("All fields are required"));
     }
+
+    // Check password length
+    if (password.length < 8) {
+      return dispatch(signInFailure("Password must be at least 8 characters long"));
+    }
+
     try {
       dispatch(signInStart());
       const res = await fetch("/api/auth/signup", {
@@ -48,6 +56,7 @@ export default function SignUp() {
       dispatch(signInFailure(error.message));
     }
   };
+
   return (
     <div className="min-h-screen mt-20">
       <div className="flex p-3 max-w-3xl mx-auto flex-col md:flex-row md:items-center gap-5">
@@ -89,7 +98,7 @@ export default function SignUp() {
               <Label value="Your password" />
               <TextInput
                 type="password"
-                placeholder="Password"
+                placeholder="Password (min. 8 characters)"
                 id="password"
                 onChange={handleChange}
               />


### PR DESCRIPTION
## Description

This pull request fixes an issue where the login and sign-up pages were accepting passwords with less than 8 characters. The new validation ensures that users must enter a password with a minimum of 8 characters.

## Changes Made

- Added password length validation to both the sign-up and login forms.
- Updated error messages to notify users if their password is too short.

## Issue Resolved

Fixes: [Issue #20 ](https://github.com/Anshul439/Blogverse/issues/20) 

## How Has This Been Tested?

- Manual testing of the login and sign-up forms with various password lengths.
- Verified that passwords less than 8 characters trigger an error message, and passwords 8 characters or longer successfully pass validation.

## Screenshots 

![image](https://github.com/user-attachments/assets/afdcb3fb-7213-4b0e-a8ae-6e9bb9bfa59e)


![image](https://github.com/user-attachments/assets/9db62953-257b-47b2-9c9c-c70c98df414b)


## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] This PR resolves an open issue.

## Additional Comments

Please let me know if further improvements are needed. Thanks for reviewing this PR!
